### PR TITLE
Fixed open redirect in contacts/ endpoint by hardcoding the redirect to the 'about' page.

### DIFF
--- a/src/contacts/views.py
+++ b/src/contacts/views.py
@@ -12,8 +12,7 @@ def contact(request):
         client_email = request.POST.get('email')
         subject = request.POST.get('subject')
         message = request.POST.get('message')
-        redirect_url = request.POST.get('redirect')
-        print(redirect_url)
+        redirect_url = "/about/"
 
         contact = Contact(name=name, subject=subject,
                           email=client_email, message=message)


### PR DESCRIPTION
Hello,
I'm a security researcher at [r2c](https://r2c.dev). We are working with Django experts to write code checks for security and runtime problems in Django.

I found an open redirect in your application in the contacts/ endpoint using a [check we wrote](https://github.com/returntocorp/sgrep-rules/tree/develop/python/django). You can read more about open redirects here: https://cwe.mitre.org/data/definitions/601.html.

I noticed that the `redirect_url` is always `/about/` coming from the front-end, so I drafted this PR to prevent the open redirect I hardcoded `/about/` as the `redirect_url`. I tested the application and it redirects to the `/about/` page just fine.

We have a [tool you can use](https://bento.dev) and a corresponding [GitHub Action](https://github.com/marketplace/actions/bento-check) that will supply checks for Django like the one used to detect this open redirect in the near future.

Thanks, and I hope this helps! Let me know if you have any questions.